### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+ADD package.json package-lock.json ./
+RUN npm install --omit=dev
+
+ADD . .
+
+CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  wallet-api:
+    image: "193924712582.dkr.ecr.us-east-1.amazonaws.com/wallet-api:latest"
+    ports:
+      - "80:3000"
+    env_file:
+      - .env


### PR DESCRIPTION
## Summary
In order to deploy to beanstalk, I'm putting the app in a docker container to ease the deployment process, the docker-compose is built to expose the service in the port 80 of the host machine (assuming the app is listening in port 300)